### PR TITLE
Fix link to GitHub repo

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,6 +1,6 @@
 # Unit contents
 
-This website is hosted on github at [github.com/cs-uob/COMS10012](https://github.com/cs-uob/COMS100120). You can clone the repository (you'll learn what this means in week 13) to have an offline copy if you prefer, and then "git pull" (you'll learn this too) to see if there have been any updates. The main page for the website is `docs/README.md`, and the subpages for different parts are fully built HTML/CSS websites. Of course, you can also just use the website online.
+This website is hosted on github at [github.com/cs-uob/COMS10012](https://github.com/cs-uob/COMS10012). You can clone the repository (you'll learn what this means in week 13) to have an offline copy if you prefer, and then "git pull" (you'll learn this too) to see if there have been any updates. The main page for the website is `docs/README.md`, and the subpages for different parts are fully built HTML/CSS websites. Of course, you can also just use the website online.
 
 Videos are hosted externally on the university systems, but we are using a trick that allows you (at the moment) to access the raw mp4 files. You can download them for offline watching if you like, but you may not share them with non-students or reupload them anywhere else online as it's not your intellectual property.
 


### PR DESCRIPTION
Removes the '0' at the end of the URL