### PR TITLE
Removes "hello class" demo line

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@ This is the repository for the unit COMS10012 Software Tools.
 If you are looking for the unit website, it is at https://cs-uob.github.io/COMS10012.
 
 To clone this repository to your computer, type `git clone https://github.com/cs-uob/COMS10012` in a terminal. This repository is public, so you do not need an account to do this.
-
-Hello Class!


### PR DESCRIPTION
Removes a spurious line from the front page of the unit, that we added when we ran this unit in the past as part of a demo.  It isn't needed now.